### PR TITLE
hhfe-1023: templatize repo URL and config path in sample app guide

### DIFF
--- a/docs/documentations/sdk/sample-application.md
+++ b/docs/documentations/sdk/sample-application.md
@@ -8,12 +8,15 @@ tags:
 
 #### 1. Download the Test App
 
-Download our test app from <a href="https://github.com/halo-dot/test_app-android_sdk" target="_blank">GitHub</a> .
+Download our test app from <a href="{{REPO_URL}}" target="_blank">GitHub</a> .
 
 #### 2. Configure The Test App
 
-Open `app/src/main/java/za/co/synthesis/halo/halotestapp/Config.kt` and replace the placeholder values of `PRIVATE_KEY_PEM`, `ISSUER`, and `USERNAME` with your own values.<br/> 
+<hr/>
+Open `"{{CONFIG_PATH}}"` and replace the placeholder values of `PRIVATE_KEY_PEM`, `ISSUER`, and `USERNAME` with your own values.<br/> 
 You will need the private key you used to generate your public key, your issuer name, and your username (you can use the email or phone number used to register).
+
+<hr/>
 
 ```kotlin
 object Config {
@@ -26,6 +29,7 @@ object Config {
     const val KSK = "{{KSK}}"
 }
 ```
+<hr/>
 
 Open the `local.properties` file and replace the placeholder values of `aws.accessKey` and `aws.secretKey`.<br/>
 These credentials are sensitive and should not be committed to source control. Add the credentials into a local.properties file:

--- a/docs/documentations/sdk/sample-application.md
+++ b/docs/documentations/sdk/sample-application.md
@@ -8,12 +8,12 @@ tags:
 
 #### 1. Download the Test App
 
-Download our test app from <a href="{{REPO_URL}}" target="_blank">GitHub</a> .
+Download our test app from <a href="{{REPO_URL}}" target="_blank" rel="noopener noreferrer">GitHub</a>.
 
 #### 2. Configure The Test App
 
 <hr/>
-Open `"{{CONFIG_PATH}}"` and replace the placeholder values of `PRIVATE_KEY_PEM`, `ISSUER`, and `USERNAME` with your own values.<br/> 
+Open `{{CONFIG_PATH}}` and replace the placeholder values of `PRIVATE_KEY_PEM`, `ISSUER`, and `USERNAME` with your own values.<br/> 
 You will need the private key you used to generate your public key, your issuer name, and your username (you can use the email or phone number used to register).
 
 <hr/>


### PR DESCRIPTION
Replace hardcoded Android repo link and config file path with {{REPO_URL}} and {{CONFIG_PATH}} placeholders, and add section dividers to prepare for per-platform tab content.